### PR TITLE
Curve apostrophe in place of typewriter apostrophe

### DIFF
--- a/src/lang/fr/validation.php
+++ b/src/lang/fr/validation.php
@@ -9,7 +9,7 @@ return array(
   'greaterthan'        => 'plus grand que :size pixels',
   'greaterthanorequal' => 'plus grand ou égal à :size pixels',
   'equal'              => ':size pixels',
-  'anysize'            => "n'importe quelle taille",
+  'anysize'            => 'n’importe quelle taille',
 
   'image_aspect'       => 'Le ratio de :attribute doit être de :aspect',
 );


### PR DESCRIPTION
It’s better to use curve apostrophes than the ugly typewriter apostrophe. More info here : http://www.creativepro.com/article/typographic-tips-apostrophes-quotation-marks