### PR TITLE
added @alpha in composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Extra Laravel validation rules for dealing with images.
 Install the package through [Composer](http://getcomposer.org).
 
 ```
-composer require "cviebrock/image-validator:2.0.*"
+composer require "cviebrock/image-validator:2.0.*@alpha"
 ```
 
 **Note:** Version 2.0 of this package is designed to work with Laravel 5.  If you are using Laravel 4, then checkout the `1.x` branch and use the latest version there.


### PR DESCRIPTION
Since you marked the lates version as alpha, we need to add @alpha in composer require, to get latest "alpha" version. That will be removed soon as you remove alpha mark.

You can merge this to remove confusion until new stabile version show up.