### PR TITLE
Fixed a typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Note that you may run into issues with floating point rounding.
 	// logo must be ready for the big screen TV :)
 
 	$rules = array(
-		'logo' => 'required|image|image_aspect:16:9',
+		'logo' => 'required|image|image_aspect:16,9',
 	);
 
 


### PR DESCRIPTION
There was a colon instead of a comma in [examples](https://github.com/cviebrock/image-validator#examples) section.